### PR TITLE
Reduce amount and size of Docker image layers

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,34 +1,27 @@
 ARG PHP_BASE_IMAGE_TAG=8.0-fpm
 
 FROM php:${PHP_BASE_IMAGE_TAG} AS sylius_php
-RUN apt update
-RUN apt install -y zlib1g-dev
-RUN apt install -y libpng-dev
-RUN apt install -y libjpeg-dev
-RUN apt install -y libfreetype6-dev
-RUN apt install -y libicu-dev
-RUN apt install -y zip
-RUN apt install -y libmemcached-dev
-RUN docker-php-ext-install gd
-RUN docker-php-ext-install exif
-RUN docker-php-ext-install fileinfo
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install pdo_mysql
-RUN docker-php-ext-install opcache
-RUN pecl install apcu
+
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+
+RUN apt-get update && \
+    apt-get install -y unzip && \
+    install-php-extensions  \
+      apcu \
+      exif \
+      fileinfo \
+      gd \
+      imagick \
+      intl \
+      memcached \
+      opcache \
+      pdo_mysql \
+      zip
 RUN docker-php-ext-enable apcu --ini-name 10-docker-php-ext-apcu.ini
-RUN pecl install memcached
 RUN docker-php-ext-enable memcached
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
-RUN apt install -y libmagickwand-dev --no-install-recommends
-RUN pecl install imagick
-RUN docker-php-ext-enable imagick
 ENV PHP_DATE_TIMEZONE="Europe/Warsaw"
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-WORKDIR /symfony
-RUN apt install -y wget
-RUN wget https://get.symfony.com/cli/installer
-RUN chmod +x installer
-RUN bash installer
-RUN mv /root/.symfony/bin/symfony /usr/local/bin/symfony
+
+RUN curl -fs https://get.symfony.com/cli/installer | bash && \
+    mv /root/.symfony/bin/symfony /usr/local/bin/symfony
 WORKDIR /


### PR DESCRIPTION
By utilizing `mlocati/php-extension-installer` I was able to reduce the layers size - under the hood `-dev` packages are installed only temporarily for the duration of extension compilation. `gd` extension still has freetype and jpeg support enabled - `php -i` can confirm this.

The one caveat with aforementioned installed is that `unzip` wasn't installed automatically and `composer` was complaining - hence the one `apt-get install` at the top.

<details>

<summary>docker image history comparison</summary>

Below you will find a comparison between an image built on original Dockerfile and after my modifications.

```
 ✘  ~/Sites/sylius/docker-images/php   master ●  docker image history sha256:80770d9234965677e14c7f601cac819e7b1885428868e867af2acfb60a32b890
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
80770d923496   4 minutes ago    WORKDIR /                                       0B        buildkit.dockerfile.v0
<missing>      4 minutes ago    RUN /bin/sh -c curl -fs https://get.symfony.…   17.7MB    buildkit.dockerfile.v0
<missing>      4 minutes ago    COPY /usr/bin/composer /usr/bin/composer # b…   2.29MB    buildkit.dockerfile.v0
<missing>      4 minutes ago    ENV PHP_DATE_TIMEZONE=Europe/Warsaw             0B        buildkit.dockerfile.v0
<missing>      4 minutes ago    RUN /bin/sh -c docker-php-ext-enable memcach…   0B        buildkit.dockerfile.v0
<missing>      4 minutes ago    RUN /bin/sh -c docker-php-ext-enable apcu --…   0B        buildkit.dockerfile.v0
<missing>      4 minutes ago    RUN /bin/sh -c apt-get update &&     apt-get…   65.1MB    buildkit.dockerfile.v0
<missing>      23 minutes ago   COPY /usr/bin/install-php-extensions /usr/lo…   124kB     buildkit.dockerfile.v0
<missing>      25 hours ago     /bin/sh -c #(nop)  CMD ["php-fpm"]              0B        
[..]
<missing>      42 hours ago     /bin/sh -c #(nop) ADD file:a2405ebb9892d98be…   80.4MB    
 ~/Sites/sylius/docker-images/php   master ●  docker image history sha256:59c52bfa1b3a7aa94adbc05f408998d4e279fe03972fd2fcaf982ad8b5cc837a
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
59c52bfa1b3a   41 minutes ago   WORKDIR /                                       0B        buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c mv /root/.symfony/bin/symfony…   17.7MB    buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c bash installer # buildkit        17.7MB    buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c chmod +x installer # buildkit    6.16kB    buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c wget https://get.symfony.com/…   6.16kB    buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c apt install -y wget # buildkit   2.34MB    buildkit.dockerfile.v0
<missing>      41 minutes ago   WORKDIR /symfony                                0B        buildkit.dockerfile.v0
<missing>      41 minutes ago   COPY /usr/bin/composer /usr/bin/composer # b…   2.29MB    buildkit.dockerfile.v0
<missing>      41 minutes ago   ENV PHP_DATE_TIMEZONE=Europe/Warsaw             0B        buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c docker-php-ext-enable imagick…   18B       buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c pecl install imagick # buildk…   2.67MB    buildkit.dockerfile.v0
<missing>      41 minutes ago   RUN /bin/sh -c apt install -y libmagickwand-…   159MB     buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c docker-php-ext-configure gd -…   124MB     buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c docker-php-ext-enable memcach…   20B       buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c pecl install memcached # buil…   962kB     buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c docker-php-ext-enable apcu --…   15B       buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c pecl install apcu # buildkit     977kB     buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c docker-php-ext-install opcach…   1.36MB    buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c docker-php-ext-install pdo_my…   35.4kB    buildkit.dockerfile.v0
<missing>      42 minutes ago   RUN /bin/sh -c docker-php-ext-install intl #…   486kB     buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c docker-php-ext-install filein…   6.79MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c docker-php-ext-install exif #…   92.9kB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c docker-php-ext-install gd # b…   547kB     buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt install -y libmemcached-d…   3.09MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt install -y zip # buildkit    2.06MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt install -y libicu-dev # b…   47.1MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt install -y libfreetype6-d…   4.96MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt install -y libjpeg-dev # …   2.71MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt install -y libpng-dev # b…   2.16MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt install -y zlib1g-dev # b…   1.49MB    buildkit.dockerfile.v0
<missing>      43 minutes ago   RUN /bin/sh -c apt update # buildkit            17.7MB    buildkit.dockerfile.v0
<missing>      25 hours ago     /bin/sh -c #(nop)  CMD ["php-fpm"]              0B        
[..]
<missing>      42 hours ago     /bin/sh -c #(nop) ADD file:a2405ebb9892d98be…   80.4MB 
```
</details>