### PR TITLE
Handle image cache resolve on Nginx side

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -6,6 +6,37 @@ server {
         try_files $uri /index.php$is_args$args;
     }
 
+    # Serve cached image or ask Sylius to resolve cache if needed
+    location ~ ^/media/cache/(?!resolve/).+ {
+        try_files $uri @resolve_image_cache;
+    }
+
+    # Image cache was missing, generate it calling resolve/ Sylius route
+    location @resolve_image_cache {
+        internal;
+        rewrite ^/media/cache/(.*)$ /media/cache/resolve/$1 break;
+        proxy_pass http://127.0.0.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Intercept redirect
+        proxy_intercept_errors on;
+        error_page 302 = @handle_image_redirect;
+    }
+
+    # Serve the image to client, not the redirect
+    location @handle_image_redirect {
+        internal;
+        rewrite ^.*$ $upstream_http_location break;
+        proxy_pass http://127.0.0.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location ~ ^/index\.php(/|$) {
         fastcgi_pass ${FASTCGI_PASS};
         fastcgi_split_path_info ^(.+\.php)(/.*)$;


### PR DESCRIPTION
Simplify usage for client that should not take care of image cache state. A common usecase is when a Storefront consume Sylius API

In image cache is missing, NginX will call Sylius with /resolve and then serve the image to the client.


### Whitout this:
```
GET /media/cache/image/xx/yy.img.jpg 404
```
Then client has to do 
```
GET /media/cache/image/resolve/xx/yy.img.jpg 302 (or 404)
GET /media/cache/image/xx/yy.img.jpg 200
```

### With this change
```
GET /media/cache/image/xx/yy.img.jpg 200 (or 404)
```
NginX takes care of checking if the cache exists and generate it if not.