### PR TITLE
Add sockets PHP extension

### DIFF
--- a/.github/workflows/buildifier.yaml
+++ b/.github/workflows/buildifier.yaml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - name: Setup go
         id: go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.17.x
+          go-version: '1.22'
 
       - name: Check out code
         uses: actions/checkout@v4.1.0

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -47,6 +47,7 @@ RUN set -eux; \
 		gd \
 		intl \
 		pdo_mysql \
+		sockets \
 		zip \
 	; \
 	pecl install \


### PR DESCRIPTION
## Summary
- Add `ext-sockets` PHP extension to the base Docker image

## Why
Required by `php-amqplib/php-amqplib` v3.1.0+ which is a dependency of `sylius/b2b-kit` for RabbitMQ message queue support.

Fixes:
<img width="949" height="907" alt="image" src="https://github.com/user-attachments/assets/c3ed42ba-71fa-4395-a465-97a3a65343dc" />

