### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/sylius-nginx.yml
+++ b/.github/workflows/sylius-nginx.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: "${{ runner.os }}-nginx-alpine-buildx-cache-${{ vars.CACHE_VERSION }}-${{ steps.generate-uuid.outputs.uuid }}"

--- a/.github/workflows/sylius-php.yml
+++ b/.github/workflows/sylius-php.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: "${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.distro }}-buildx-cache-${{ vars.CACHE_VERSION }}-${{ steps.generate-uuid.outputs.uuid }}"
@@ -115,7 +115,7 @@ jobs:
           outputs: type=docker,dest=./external/image-arm64.tar
 
       - name: Mount Bazel cache
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: "~/.cache/bazel"
           key: "${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.distro }}-bazel-cache-${{ vars.CACHE_VERSION }}-${{ steps.generate-uuid.outputs.uuid }}"
@@ -196,7 +196,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: "${{ runner.os }}-php-xdebug-${{ matrix.php }}-${{ matrix.distro }}-buildx-cache-${{ vars.CACHE_VERSION }}-${{ steps.generate-uuid.outputs.uuid }}"
@@ -279,7 +279,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: "${{ runner.os }}-php-fixuid-${{ matrix.php }}-${{ matrix.version }}-buildx-cache-${{ vars.CACHE_VERSION }}-${{ steps.generate-uuid.outputs.uuid }}"


### PR DESCRIPTION
GitHub deprecated `actions/cache@v4.0.0` causing workflow failures. Updated to `actions/cache@v4` in both `sylius-nginx.yml` and `sylius-php.yml` workflows.

Ref: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/