### PR TITLE
Add linux-headers for sockets extension on Alpine

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -29,6 +29,7 @@ RUN set -eux; \
 		libtool \
 		libwebp-dev \
 		libzip-dev \
+		linux-headers \
 		zlib-dev \
 	; \
 	\


### PR DESCRIPTION
Adds `linux-headers` to build dependencies required for compiling the `sockets` PHP extension on Alpine Linux.

Without this package, building images with `ext-sockets` fails with missing `linux/sock_diag.h` header.

Ref: https://github.com/docker-library/php/issues/1500