### PR TITLE
Add configurable memory_limit to php.ini

### DIFF
--- a/php/php.ini
+++ b/php/php.ini
@@ -11,5 +11,6 @@ opcache.memory_consumption = 256
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
 
+memory_limit = ${PHP_MEMORY_LIMIT:-1G}
 post_max_size = 6M
 upload_max_filesize = 5M


### PR DESCRIPTION
## Summary
- Add `memory_limit` setting to `php.ini` (missing, causing 128M default)
- Default to 1G (suitable for development with Xdebug/Profiler)
- Configurable via `PHP_MEMORY_LIMIT` environment variable for production

## Problem
First request to Sylius container fails with "Allowed memory size of 134217728 bytes exhausted" because Symfony needs to compile DI container cache, which requires more than 128M.


The problem occurs only once when opening the app for the first time:
<img width="1325" height="243" alt="image" src="https://github.com/user-attachments/assets/ac7f80be-fa05-40d3-a230-7c0daedf2992" />
