### PR TITLE
Install APCu and Xdebug from source due to PECL shutdown

### DIFF
--- a/.github/workflows/buildifier.yaml
+++ b/.github/workflows/buildifier.yaml
@@ -16,7 +16,7 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: 'stable'
 
       - name: Check out code
         uses: actions/checkout@v4.1.0

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -51,10 +51,12 @@ RUN set -eux; \
 		sockets \
 		zip \
 	; \
-	pecl install \
-		apcu-${APCU_VERSION} \
-	; \
-	pecl clear-cache; \
+	# pecl.php.net is being decommissioned, install APCu from source
+	wget -O /tmp/apcu.tar.gz "https://github.com/krakjoe/apcu/archive/refs/tags/v${APCU_VERSION}.tar.gz"; \
+	mkdir -p /usr/src/php/ext/apcu; \
+	tar -xzf /tmp/apcu.tar.gz -C /usr/src/php/ext/apcu --strip-components=1; \
+	rm /tmp/apcu.tar.gz; \
+	docker-php-ext-install -j$(nproc) apcu; \
     # Opcache is built into core of PHP binary from version 8.5
     if [[ 1 -eq "$(echo "$PHP_SHORT_VERSION < 8.5" | bc)" ]] ; \
         then \

--- a/php/xdebug.Dockerfile
+++ b/php/xdebug.Dockerfile
@@ -9,6 +9,10 @@ ARG XDEBUG_VERSION
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps $PHPIZE_DEPS linux-headers; \
-	pecl install xdebug-$XDEBUG_VERSION; \
-	docker-php-ext-enable xdebug; \
+	# pecl.php.net is being decommissioned, install Xdebug from source
+	wget -O /tmp/xdebug.tar.gz "https://github.com/xdebug/xdebug/archive/refs/tags/$XDEBUG_VERSION.tar.gz"; \
+	mkdir -p /usr/src/php/ext/xdebug; \
+	tar -xzf /tmp/xdebug.tar.gz -C /usr/src/php/ext/xdebug --strip-components=1; \
+	rm /tmp/xdebug.tar.gz; \
+	docker-php-ext-install -j$(nproc) xdebug; \
 	apk del .build-deps


### PR DESCRIPTION
Weekly image builds fail because pecl.php.net currently returns 504 (PECL infrastructure is being phased out in favour of PIE), so `pecl install` can no longer fetch APCu and Xdebug. Both extensions are now downloaded as source tarballs from their GitHub releases and built with `docker-php-ext-install`, keeping the same pinned versions.

Also bumps the buildifier workflow to stable Go, since `buildifier@latest` no longer compiles on Go 1.22.

Verified locally on PHP 8.4: base and xdebug images build, `apcu`, `Zend OPcache`, `sodium` and `xdebug` modules load, hadolint passes.