### PR TITLE
Pass explicit platform to container-structure-test

### DIFF
--- a/.github/workflows/sylius-php.yml
+++ b/.github/workflows/sylius-php.yml
@@ -123,13 +123,13 @@ jobs:
         run: |
           set -ex
           docker load -i ./external/image-amd64.tar
-          container-structure-test test --image ${{ steps.meta.outputs.tags }} --config php/testdata/php${{ matrix.php }}_amd64.yaml
+          container-structure-test test --platform linux/amd64 --image ${{ steps.meta.outputs.tags }} --config php/testdata/php${{ matrix.php }}_amd64.yaml
 
       - name: Structure tests (arm64)
         run: |
           set -ex
           docker load -i ./external/image-arm64.tar
-          container-structure-test test --image ${{ steps.meta.outputs.tags }} --config php/testdata/php${{ matrix.php }}_arm64.yaml
+          container-structure-test test --platform linux/arm64 --image ${{ steps.meta.outputs.tags }} --config php/testdata/php${{ matrix.php }}_arm64.yaml
 
       - name: Push
         uses: docker/build-push-action@v5.0.0


### PR DESCRIPTION
Follow-up to #17. The arm64 structure tests failed because container-structure-test defaults to the host platform, so creating a container from the freshly loaded arm64 image errored with "its platform (linux/arm64) does not match the specified platform (linux/amd64)". Both test steps now pass an explicit --platform matching the tested image; arm64 commands run through the QEMU emulation already configured in the job.